### PR TITLE
feat!: dump Gridelements TypoScript dependency

### DIFF
--- a/Classes/DataProcessing/GridChildrenProcessor.php
+++ b/Classes/DataProcessing/GridChildrenProcessor.php
@@ -2,6 +2,9 @@
 
 namespace ITplusX\HeadlessGridelements\DataProcessing;
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
 /**
  * Fetch records from the database, using the default .select syntax from TypoScript.
  */
@@ -12,6 +15,14 @@ class GridChildrenProcessor extends \GridElementsTeam\Gridelements\DataProcessin
      */
     protected function sortRecordsIntoMatrix()
     {
+        $processedColumns = [];
+        foreach ($this->processedRecordVariables as $key => $processedRecord) {
+            if (!isset($processedColumns[$processedRecord['data']['tx_gridelements_columns']])) {
+                $processedColumns[$processedRecord['data']['tx_gridelements_columns']] = [];
+            }
+            $processedColumns[$processedRecord['data']['tx_gridelements_columns']][] = $processedRecord;
+        }
+
         $processedRows = [];
         if (!empty($this->processedData['data']['tx_gridelements_backend_layout_resolved'])) {
             foreach ($this->processedData['data']['tx_gridelements_backend_layout_resolved']['config']['rows.'] as $rowNumber => $row) {
@@ -19,21 +30,49 @@ class GridChildrenProcessor extends \GridElementsTeam\Gridelements\DataProcessin
                 foreach ($row['columns.'] as $column) {
                     $columns[] = [
                         'config' => $column,
-                        'elements' => array_map(
-                            'trim',
-                            (
-                                array_slice(
-                                    explode('###BREAK###', $this->processedData['data']['tx_gridelements_view_columns'][$column['colPos']]),
-                                    0,
-                                    -1
-                                )
-                            )
-                        )
+                        'elements' => is_array($processedColumns[$column['colPos']]) === true ? $this->processRecords($processedColumns[$column['colPos']]) : []
                     ];
                 }
+
                 $processedRows[]['columns'] = $columns;
             }
         }
+
         return $processedRows;
+    }
+
+    /**
+     * Process the records to be rendered as JSON
+     *
+     * @param array $records The array of records to process
+     * @return array The processed records as JSON
+     */
+    private function processRecords(array $records): array {
+        $processedRecords = [];
+
+        foreach ($records as $record) {
+            $processedRecords[] = $this->renderRecord($record['data']);
+        }
+
+        return $processedRecords;
+    }
+
+    /**
+     * Render a record as JSON by given data array
+     *
+     * @param array $data The record data
+     * @return string The JSON string of the rendered record
+     */
+    private function renderRecord(array $data): string {
+        $recordContentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $recordContentObjectRenderer->start($data, 'tt_content');
+
+        $conf = [
+            'tables' => 'tt_content',
+            'source' => $data['uid'],
+            'dontCheckPid' => 1
+        ];
+
+        return $recordContentObjectRenderer->cObjGetSingle('RECORDS', $conf);
     }
 }

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -4,5 +4,5 @@ defined('TYPO3_MODE') || die('Access denied.');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'headless_gridelements',
     'Configuration/TypoScript',
-    'Grid Elements json output for EXT:headless'
+    'Headless Gridelements'
 );

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,12 +1,8 @@
-lib.gridelements.defaultGridSetup {
-    # Seperate grid column content with a seperator
-    columns.default.renderObj.stdWrap.innerWrap = |###BREAK###
-
-    cObject =< lib.contentElementWithHeader
-
-    # Add custom fields
-    cObject.fields {
-        # Override CE type
+tt_content.gridelements_pi1 >
+tt_content.gridelements_pi1 =< lib.contentElementWithHeader
+tt_content.gridelements_pi1 {
+    fields {
+        # Override CE type display
         type.stdWrap.cObject = TEXT
         type.stdWrap.cObject.value = structured_content
 
@@ -34,8 +30,4 @@ lib.gridelements.defaultGridSetup {
             }
         }
     }
-}
-
-tt_content.gridelements_pi1.20.10.setup {
-    default < lib.gridelements.defaultGridSetup
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ see: [Installation and Upgrade Guide](https://docs.typo3.org/m/typo3/guide-insta
 ## Usage
 After a successful install just include the TypoScript of this package and you are ready to go.
 
+**NOTE:  
+Including the original Gridelements TypoScript might break the JSON output. Therefore it is not recommended to do so. 
+The TypoScript of `headless_gridelements` is enough.**
+
 ## Example json output
 ```json
 {


### PR DESCRIPTION
Make the headless_gridelement TypoScript standalone without the need of the original Gridelements TypoScript.

BREAKING CHANGE: It's now unnecessary to include the Gridelements TypoScript. Furthermore, including it might break the JSON output.

Resolves #5