### PR TITLE
build(composer): provide extension key to resolve deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,9 @@
   "extra": {
     "branch-alias": {
       "dev-master": "2.0.x-dev"
+    },
+    "typo3/cms": {
+      "extension-key": "headless_gridelements"
     }
   }
 }


### PR DESCRIPTION
Warning when installing package via composer:
```
The TYPO3 extension package "itplusx/headless-gridelements", does not define an extension key in its composer.json. Please report this to the author of this package. Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)
```