### PR TITLE
fix: sorting of gridelement children within CType `menu_section`

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -32,8 +32,9 @@ tt_content.gridelements_pi1 {
     }
 }
 
-# More advanced sorting of elements within CType 'menu_section' so
-# gridelement children are being put right after their parents:
+# More advanced sorting of elements within CType 'menu_section' so gridelement children are
+# being put right after their parents.
+# Inspired by http://blog.sitegefuehl.de/typo3-inhaltsverzeichnis-section-index-gridelements/
 tt_content.menu_section.fields.content.fields.menu.dataProcessing.10.dataProcessing.20 {
     where = tt_content.sectionIndex = 1
     selectFields (

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -31,3 +31,17 @@ tt_content.gridelements_pi1 {
         }
     }
 }
+
+# More advanced sorting of elements within CType 'menu_section' so
+# gridelement children are being put right after their parents:
+tt_content.menu_section.fields.content.fields.menu.dataProcessing.10.dataProcessing.20 {
+    where = tt_content.sectionIndex = 1
+    selectFields (
+        tt_content.uid, tt_content.header,
+        ((IFNULL(container.sorting, tt_content.sorting) * 100000000) +
+         (tt_content.tx_gridelements_columns * 10000) +
+         tt_content.sorting) as customSorting
+    )
+    leftjoin = tt_content AS container ON container.uid = tt_content.tx_gridelements_container
+    orderBy = customSorting
+}


### PR DESCRIPTION
Due to their separate `sorting` order per grid column any grid child is placed on top of the menu rendered by CType `menu_section`. This fixes that situation by taking grid parent and column into the calculation of a custom order.

Inspired by http://blog.sitegefuehl.de/typo3-inhaltsverzeichnis-section-index-gridelements/