### PR TITLE
fix: CType menu_section broken for translated 'free mode' pages

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -38,7 +38,7 @@ tt_content.gridelements_pi1 {
 tt_content.menu_section.fields.content.fields.menu.dataProcessing.10.dataProcessing.20 {
     where = tt_content.sectionIndex = 1
     selectFields (
-        tt_content.uid, tt_content.header,
+        tt_content.uid, tt_content.header, tt_content.sys_language_uid, tt_content.l18n_parent,
         ((IFNULL(container.sorting, tt_content.sorting) * 100000000) +
          (tt_content.tx_gridelements_columns * 10000) +
          tt_content.sorting) as customSorting


### PR DESCRIPTION
For determining the language overlay TYPO3 (`PageRepository->getRecordOverlay()`) requires the two fields sys_language_uid and l18n_parent to be present.

Patch should be compatible for 2.x and 3.x. Would appreciate if there was a 2.x branch and a new release `2.1.1` with this patch :heart_eyes: 