### PR TITLE
Update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^7.4 || ^8.0",
     "typo3/cms-core": "^11.5",
     "friendsoftypo3/headless": "^3.0",
-    "gridelementsteam/gridelements": "dev-master as 11.0"
+    "gridelementsteam/gridelements": "^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,13 +8,13 @@ $EM_CONF[$_EXTKEY] = [
     'author_email' => 'schlosser@itplusx.de',
     'author_company' => 'ITplusX GmbH',
     'state' => 'stable',
-    'version' => '3.0.0-dev',
+    'version' => '3.0.0',
     'constraints' => [
         'depends' => [
-            'php' => '7.2.0-0.0.0',
+            'php' => '7.2.0-8.2.99',
             'typo3' => '11.5.0-11.5.99',
             'headless' => '3.0.0-3.99.99',
-            'gridelements' => '11.0.0-dev',
+            'gridelements' => '11.0.0-11.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
After the release of EXT:gridelements 11.0 we can finally update the version constraints to a stable major version and release this extension as 3.0